### PR TITLE
Delegation with extra args inlined into signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,7 @@ impl syn::parse::Parse for DelegatedMethod {
         let paren_token = syn::parenthesized!(content in input);
 
         // Parse inputs (method parameters) and arguments. The parameters
-        // constitute a the parameter list of the signature of the delegating
+        // constitute the parameter list of the signature of the delegating
         // method so it must include all inputs, except bracketed expressions.
         // The argument list constitutes the list of arguments used to call the
         // delegated function. It must include all inputs, excluding the
@@ -578,15 +578,13 @@ pub fn delegate(tokens: TokenStream) -> TokenStream {
                 }
             };
 
-            let x = quote::quote_spanned! {span=>
+            quote::quote_spanned! {span=>
                 #(#attrs)*
                 #inline
                 #visibility #signature {
                     #body
                 }
-            };
-
-            x
+            }
         });
 
         quote! { #(#functions)* }

--- a/tests/inline_args.rs
+++ b/tests/inline_args.rs
@@ -1,0 +1,112 @@
+extern crate delegate;
+
+use delegate::delegate;
+
+#[test]
+fn test_inline_args() {
+    struct Inner;
+
+    impl Inner {
+        fn fun_generic<S: Copy>(self, s: S) -> S {
+            s
+        }
+        fn fun0(self) -> u32 {
+            42
+        }
+        fn fun1(self, a: u32) -> u32 {
+            a
+        }
+        fn fun2(self, a: u32, b: u32) -> u32 {
+            a + b
+        }
+        fn fun3(&self, a: u32, b: u32, c: u32) -> u32 {
+            a + b + c
+        }
+    }
+
+    struct Outer {
+        inner: Inner,
+        value: u32,
+    }
+
+    impl Outer {
+        pub fn new() -> Outer {
+            Outer {
+                inner: Inner,
+                value: 42,
+            }
+        }
+
+        delegate! {
+            to self.inner {
+                #[call(fun_generic)]
+                fn fun_generic(self, [ 42 ]) -> u32;
+                #[call(fun1)]
+                fn fun1_with_0(self, [ 0 ]) -> u32;
+                #[call(fun1)]
+                fn fun1_with_0_no_spaces(self, [0]) -> u32;
+                #[call(fun1)]
+                fn fun1_with_def(self, [ self.value ] ) -> u32;
+                fn fun2(self, [ 0 ], b: u32) -> u32;
+                #[append_args(2)]
+                fn fun3(self, a: u32, [ 2 ]) -> u32;
+            }
+        }
+    }
+
+    assert_eq!(Outer::new().fun_generic(), 42);
+    assert_eq!(Outer::new().fun1_with_0(), 0);
+    assert_eq!(Outer::new().fun1_with_0_no_spaces(), 0);
+    assert_eq!(Outer::new().fun1_with_def(), 42);
+    assert_eq!(Outer::new().fun2(2), 2);
+    assert_eq!(Outer::new().fun3(3), 7);
+}
+
+#[test]
+fn test_mixed_args() {
+    use delegate::delegate;
+    struct Inner;
+    impl Inner {
+        pub fn polynomial(&self, a: i32, x: i32, b: i32, y: i32, c: i32) -> i32 {
+            a + x * x + b * y + c
+        }
+    }
+    struct Wrapper {
+        inner: Inner,
+        a: i32,
+        b: i32,
+        c: i32,
+    }
+    impl Wrapper {
+        delegate! {
+            to self.inner {
+                pub fn polynomial(&self, [ self.a ], x: i32, [ self.b ], y: i32, [ self.c ]) -> i32 ;
+
+                #[call(polynomial)]
+                #[append_args(0, 0, 0, 0)]
+                pub fn constant(&self, a: i32) -> i32;
+
+                #[call(polynomial)]
+                pub fn linear(&self, [ 0 ], [ 0 ], [ self.b ], y: i32, [ self.c ]) -> i32 ;
+
+                #[call(polynomial)]
+                #[append_args(0, 0, self.c)]
+                pub fn univariate_quadratic(&self, [ self.a ], x: i32) -> i32 ;
+            }
+        }
+
+        pub fn new() -> Wrapper {
+            Wrapper {
+                inner: Inner,
+                a: 1,
+                b: 3,
+                c: 5,
+            }
+        }
+    }
+
+    assert_eq!(Wrapper::new().polynomial(2, 3), 19i32);
+    assert_eq!(Wrapper::new().constant(7), 7i32);
+    assert_eq!(Wrapper::new().linear(3), 14i32);
+    assert_eq!(Wrapper::new().univariate_quadratic(2), 10i32);
+}


### PR DESCRIPTION
Stemming from the conversation in PR #31:

The idea is to add argument expressions at arbitrary positions into the delegated methods. These expressions are marked by square brackets. The method would generate a signature without these arguments, but the call to the method on the inner object would generate these expressions in the argument list at the appropriate positions.

Example:

```rust
delegate! {
    to self.inner {
        pub fn method(&self, a: u32, [ 0 ], c: u32, [ self.default_offset ]) -> u32;
    }
}
```

Generates into:

```rust
pub fn method(&self, a: u32, c: u32) -> u32 {
    self.inner.method(a, 0, c, self.default_offset)
}
```