### PR TITLE
Add `#[from]` argument modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,33 @@ impl Wrapper {
     }
 }
 ```
+- Modify how will an input parameter be passed to the delegated method with parameter attribute modifiers.
+Currently, the following modifiers are supported:
+    - `#[into]`: Calls `.into()` on the parameter passed to the delegated method.
+```rust
+use delegate::delegate;
+//!
+struct InnerType {}
+impl InnerType {
+    fn foo(&self, other: Self) {}
+}
+//!
+impl From<Wrapper> for InnerType {
+    fn from(wrapper: Wrapper) -> Self {
+        wrapper.0
+    }
+}
+//!
+struct Wrapper(InnerType);
+impl Wrapper {
+    delegate! {
+        to self.0 {
+            // Calls `self.0.foo(other.into());`
+            pub fn foo(&self, #[into] other: Self);
+        }
+    }
+}
+```
 
 ## License
 

--- a/tests/argument_modifier.rs
+++ b/tests/argument_modifier.rs
@@ -1,0 +1,25 @@
+use delegate::delegate;
+
+struct MyNewU32(u32);
+
+trait Foo {
+    fn bar(&self, x: Self);
+}
+
+impl Foo for u32 {
+    fn bar(&self, x: Self) {}
+}
+
+impl From<MyNewU32> for u32 {
+    fn from(value: MyNewU32) -> Self {
+        value.0
+    }
+}
+
+impl Foo for MyNewU32 {
+    delegate! {
+        to self.0 {
+            fn bar(&self, #[into] x: Self);
+        }
+    }
+}


### PR DESCRIPTION
I decided to name the attribute `#[into]` and not `#[from]`, since there is already an `#[into]` attribute in the plugin. I also realized that `#[deref]` is useless, since the compiler auto derefs by default. @AZMCode could you check that this PR solves your issue?

Fixes: https://github.com/Kobzol/rust-delegate/issues/40