### PR TITLE
Implement `as_ref` argument modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ impl Wrapper {
   parameter attribute modifiers. Currently, the following modifiers are
   supported:
   - `#[into]`: Calls `.into()` on the parameter passed to the delegated method.
+  - `#[as_ref]`: Calls `.as_ref()` on the parameter passed to the delegated method.
 
 ```rust
 use delegate::delegate;

--- a/tests/argument_modifier.rs
+++ b/tests/argument_modifier.rs
@@ -23,3 +23,18 @@ impl Foo for MyNewU32 {
         }
     }
 }
+
+struct Bar {
+    foo: String,
+}
+
+impl<T> PartialEq<T> for Bar
+where
+    T: AsRef<str> + ?Sized,
+{
+    delegate! {
+        to self.foo {
+            fn eq(&self, #[as_ref] other: &T) -> bool;
+        }
+    }
+}


### PR DESCRIPTION
It is often not enough to have '#[into]' only for arguments.
A use case:
```rust
#[derive(Clone, Debug)]
pub struct Ident {
    inner: syn::Ident,
    string: String,
}

impl<T> PartialEq<T> for Ident
where
    T: AsRef<str> + ?Sized,
{
    delegate! {
        to self.string {
            fn eq(&self, #[as_ref] other: &T) -> bool;
            //fn eq(&self, #[into] other: &T) -> bool; - doesn't compile
        }
    }
}
```