### PR TITLE
Upgrade to syn 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = [
 ]
 
 [dependencies]
-syn = { version = "1", features = ["full", "visit-mut"] }
+syn = { version = "2", features = ["full", "visit-mut"] }
 quote = "1"
 proc-macro2 = "1"
 


### PR DESCRIPTION
Upgrade the dependency `syn` to 2.0.

The major changes in `syn` 2.0 related to this crate:
- structure of `Attribute` changes, and `Attribute::parse_meta` is replaced by `Attribute::parse_nested_meta` and `Attribute::parse_args[_with]`
- dtolnay/syn#1458

The first is trivial to handle. The parentheses of attributes are now dealt with by `Attribute::parse_args`, so I removed the parsing for parentheses in `CallMethodAttribute`, `IntoAttribute`, etc. The second one is more tricky, because `await` is now considered a keyword and `#[await(true)]` is rejected by `Attribute::parse_outer`. I had to duplicate the relevant parsing functions from `syn` and make a tolerant variation (see `tolerant_outer_attributes` in `lib.rs`).

All the tests pass, and there should not be any breaking changes.