### PR TITLE
Allow delegating an associated function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 # Dev
+- Allow delegating an associated function (not just a method).
+```rust
+struct A {}
+impl A {
+    fn foo(a: u32) -> u32 {
+        a + 1
+    }
+}
+
+struct B;
+impl B {
+    delegate! {
+        to A {
+            fn foo(a: u32) -> u32;
+        }
+    }
+}
+```
 - Allow specifying certain attributes (e.g. `#[into]` or `#[unwrap]`) on delegated segments.
 The attribute will then be applied to all methods in that segment (unless it is overwritten on the method itself).
 ```rust

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -731,6 +731,8 @@ pub fn delegate(tokens: TokenStream) -> TokenStream {
             };
             let visibility = &method.visibility;
 
+            let is_method = method.method.sig.receiver().is_some();
+
             let span = input.span();
             let body = if let syn::Expr::Match(expr_match) = delegator_attribute {
                 let mut expr_match = expr_match.clone();
@@ -742,8 +744,10 @@ pub fn delegate(tokens: TokenStream) -> TokenStream {
                 expr_match.into_token_stream()
             } else if let Some(target_trait) = attributes.target_trait {
                 quote::quote! { #target_trait::#name(#delegator_attribute, #(#args),*) }
-            } else {
+            } else if is_method {
                 quote::quote! { #delegator_attribute.#name(#(#args),*) }
+            } else {
+                quote::quote! { #delegator_attribute::#name(#(#args),*) }
             };
 
             let generate_await = attributes

--- a/tests/function.rs
+++ b/tests/function.rs
@@ -1,0 +1,23 @@
+use delegate::delegate;
+
+#[test]
+fn test_delegate_function() {
+    struct A {}
+    impl A {
+        fn foo(a: u32) -> u32 {
+            a + 1
+        }
+    }
+
+    struct B;
+
+    impl B {
+        delegate! {
+            to A {
+                fn foo(a: u32) -> u32;
+            }
+        }
+    }
+
+    assert_eq!(B::foo(1), 2);
+}


### PR DESCRIPTION
Fixes: https://github.com/Kobzol/rust-delegate/issues/57