### PR TITLE
Change default inlining mode to `#[inline]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ impl Foo {
   }
 }
 ```
+- Change the default inlining mode from `#[inline(always)]` to `#[inline]` (https://github.com/Kobzol/rust-delegate/issues/61).
 
 # 0.11.0 (4. 12. 2023)
 - Allow delegating an associated function (not just a method).

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -304,7 +304,7 @@ pub fn combine_attributes<'a>(
         if !method_attrs
             .attributes
             .iter()
-            .any(|attr| attr.path().get_ident() != other_attr.path().get_ident())
+            .any(|attr| attr.path().get_ident() == other_attr.path().get_ident())
         {
             method_attrs.attributes.push(other_attr);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -759,7 +759,7 @@ pub fn delegate(tokens: TokenStream) -> TokenStream {
             let inline = if has_inline_attribute(&attributes.attributes) {
                 quote!()
             } else {
-                quote! { #[inline(always)] }
+                quote! { #[inline] }
             };
             let visibility = &method.visibility;
 


### PR DESCRIPTION
It is perhaps a safer choice to use `#[inline]`, rather than `#[inline(always)]`, since Rust often inlines bottom-up. The inlining attribute can still be overridden either per method or per segment:
```rust
impl Foo {
   delegate! {
      #[inline(always)] // apply to all methods in this segment
      to self.0 {
         #[inline(never)] // apply to this specific method
         fn foo(&self);
      }
   }
}
```

Closes: https://github.com/Kobzol/rust-delegate/issues/61