### PR TITLE
feat: Add `newtype` parameter attribute modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Dev
+- Add new `#[newtype]` function parameter modifier ([#64](https://github.com/Kobzol/rust-delegate/pull/64)).
+  Implemented by [Techassi](https://github.com/Techassi)
+
 - Allow passing arbitrary attributes to delegation segments:
 ```rust
 impl Foo {

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ impl<T> Stack<T> {
   supported:
   - `#[into]`: Calls `.into()` on the parameter passed to the delegated method.
   - `#[as_ref]`: Calls `.as_ref()` on the parameter passed to the delegated method.
+  - `#[newtype]`: Calls `.0` on the parameter passed to the delegated method.
 
   ```rust
   use delegate::delegate;
@@ -339,6 +340,8 @@ impl<T> Stack<T> {
           to self.0 {
               // Calls `self.0.foo(other.into());`
               pub fn foo(&self, #[into] other: Self);
+              // Calls `self.0.bar(other.0);`
+              pub fn bar(&self, #[newtype] other: Self);
           }
       }
   }

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ impl<T> Stack<T> {
   supported:
   - `#[into]`: Calls `.into()` on the parameter passed to the delegated method.
   - `#[as_ref]`: Calls `.as_ref()` on the parameter passed to the delegated method.
-  - `#[newtype]`: Calls `.0` on the parameter passed to the delegated method.
+  - `#[newtype]`: Accesses the first tuple element (`.0`) of the parameter passed to the delegated method.
 
   ```rust
   use delegate::delegate;

--- a/tests/argument_modifier.rs
+++ b/tests/argument_modifier.rs
@@ -38,3 +38,13 @@ where
         }
     }
 }
+
+struct Baz(Vec<u32>);
+
+impl Baz {
+    delegate! {
+        to self.0 {
+            fn extend(&mut self, #[newtype] other: Baz);
+        }
+    }
+}


### PR DESCRIPTION
This adds a new parameter attribute modifier `newtype`. This enables code like this:

```rust
struct Baz(Vec<u32>);

impl Baz {
    delegate! {
        to self.0 {
            fn extend(&mut self, #[newtype] other: Baz);
        }
    }
}
```

which will generate the following code:

```rust
#[inline]
fn extend(&mut self, other: Baz) {
    self.0.extend(other.0);
}
```

This new modifier enables access to the inner value of a newtype struct.