### PR TITLE
fix cannot delegating multiple methods when adding additional arguments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@
 //! ```
 //! - Inserts `#[inline(always)]` automatically (unless you specify `#[inline]` manually on the method)
 //! - You can use an attribute on a whole segment to automatically apply it to all methods in that
-//! segment:
+//!   segment:
 //! ```rust
 //! use delegate::delegate;
 //!
@@ -245,7 +245,7 @@
 //! }
 //! ```
 //! - Modify how will an input parameter be passed to the delegated method with parameter attribute modifiers.
-//! Currently, the following modifiers are supported:
+//!   Currently, the following modifiers are supported:
 //!     - `#[into]`: Calls `.into()` on the parameter passed to the delegated method.
 //!     - `#[as_ref]`: Calls `.as_ref()` on the parameter passed to the delegated method.
 //!     - `#[newtype]`: Calls `.0` on the parameter passed to the delegated method.
@@ -274,7 +274,7 @@
 //! }
 //! ```
 //! - Specify a trait through which will the delegated method be called
-//! (using [UFCS](https://doc.rust-lang.org/reference/expressions/call-expr.html#disambiguating-function-calls).
+//!   (using [UFCS](https://doc.rust-lang.org/reference/expressions/call-expr.html#disambiguating-function-calls).
 //! ```rust
 //! use delegate::delegate;
 //!
@@ -301,6 +301,44 @@
 //!     }
 //! }
 //! ```
+//!
+//! - Add additional arguments to method
+//!
+//!  ```rust
+//!  use delegate::delegate;
+//!  use std::cell::OnceCell;
+//!  struct Inner(u32);
+//!  impl Inner {
+//!      pub fn new(m: u32) -> Self {
+//!          // some "very complex" constructing work
+//!          Self(m)
+//!      }
+//!      pub fn method(&self, n: u32) -> u32 {
+//!          self.0 + n
+//!      }
+//!  }
+//!  
+//!  struct Wrapper {
+//!      inner: OnceCell<Inner>,
+//!  }
+//!  
+//!  impl Wrapper {
+//!      pub fn new() -> Self {
+//!          Self {
+//!              inner: OnceCell::new(),
+//!          }
+//!      }
+//!      fn content(&self, val: u32) -> &Inner {
+//!          self.inner.get_or_init(|| Inner(val))
+//!      }
+//!      delegate! {
+//!          to |k: u32| self.content(k) {
+//!              // `wrapper.method(k, num)` will call `self.content(k).method(num)`
+//!              pub fn method(&self, num: u32) -> u32;
+//!          }
+//!      }
+//!  }
+//!  ```
 //! - Delegate associated functions
 //!   ```rust
 //!   use delegate::delegate;
@@ -733,7 +771,7 @@ impl<F: Fn(&Expr) -> proc_macro2::TokenStream> VisitMut for MatchVisitor<F> {
 pub fn delegate(tokens: TokenStream) -> TokenStream {
     let block: DelegationBlock = syn::parse_macro_input!(tokens);
     let sections = block.segments.iter().map(|delegator| {
-        let mut delegated_expr = &delegator.delegator;
+        let delegated_expr = &delegator.delegator;
         let functions = delegator.methods.iter().map(|method| {
             let input = &method.method;
             let mut signature = input.sig.clone();
@@ -797,9 +835,11 @@ pub fn delegate(tokens: TokenStream) -> TokenStream {
             let is_method = method.method.sig.receiver().is_some();
 
             // Use the body of a closure (like `|k: u32| <body>`) as the delegation expression
-            if let Expr::Closure(closure) = delegated_expr {
-                delegated_expr = &closure.body;
-            }
+            let delegated_body = if let Expr::Closure(closure) = delegated_expr {
+                &closure.body
+            } else {
+                delegated_expr
+            };
 
             let span = input.span();
             let generate_await = attributes
@@ -841,12 +881,12 @@ pub fn delegate(tokens: TokenStream) -> TokenStream {
                 }
                 body
             };
-            let mut body = if let Expr::Match(expr_match) = delegated_expr {
+            let mut body = if let Expr::Match(expr_match) = delegated_body {
                 let mut expr_match = expr_match.clone();
                 MatchVisitor(modify_expr).visit_expr_match_mut(&mut expr_match);
                 expr_match.into_token_stream()
             } else {
-                modify_expr(delegated_expr)
+                modify_expr(delegated_body)
             };
 
             if let syn::ReturnType::Default = &signature.output {

--- a/tests/closure.rs
+++ b/tests/closure.rs
@@ -8,6 +8,10 @@ fn test_delegate_closure() {
         fn method(&self, n: u32) -> u32 {
             self.0 + n
         }
+
+        fn method2(&self, n: u32) -> u32 {
+            self.0 - n
+        }
     }
 
     struct Wrapper {
@@ -26,13 +30,16 @@ fn test_delegate_closure() {
         delegate! {
             to |k: u32| self.content(k) {
                 pub fn method(&self, num: u32) -> u32;
+                pub fn method2(&self, num: u32) -> u32;
             }
         }
     }
 
     let wrapper = Wrapper::new();
     assert_eq!(wrapper.method(1, 2), 3);
+    assert_eq!(wrapper.method2(1, 1), 0);
     assert_eq!(wrapper.method(1, 3), 4);
+    assert_eq!(wrapper.method2(1, 0), 1);
 }
 
 #[test]
@@ -42,19 +49,26 @@ fn test_delegate_closure_associated_function() {
         fn method(n: u32) -> u32 {
             n + 1
         }
+
+        fn method2(n: u32) -> u32 {
+            n - 1
+        }
     }
 
     struct Wrapper;
 
     impl Wrapper {
-        // Doesn't really make sense, but should copmile
+        // Doesn't really make sense, but should compile
         delegate! {
             to |k: u32| Inner {
                 pub fn method(num: u32) -> u32;
+                pub fn method2(num: u32) -> u32;
             }
         }
     }
 
     assert_eq!(Wrapper::method(1, 2), 3);
+    assert_eq!(Wrapper::method2(1, 1), 0);
     assert_eq!(Wrapper::method(1, 3), 4);
+    assert_eq!(Wrapper::method(1, 0), 1);
 }


### PR DESCRIPTION
Currently when trying to delegating multiple methods when adding additional arguments, the macro won't add additional argument on the methods except the first one, eg.

```rust
delegate! {
        to |k: u32| Inner {
            pub fn method(num: u32) -> u32;
            pub fn method2(num: u32) -> u32;
        }
    }
```

is expanded to:

```rust
#[inline]
pub fn method(k: u32, num: u32) -> u32 {
    Inner::method(num)
}
#[inline]
pub fn method2(/*Missing `k: u32,` here! */num: u32) -> u32 {
    Inner::method2(num)
}
```

This pr fix this problem.

This pr also sync the document from readme.