### PR TITLE
Make `#[into]` and `#[try_into]` generate `no_std`-compatible code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ impl Common {
 }
 ```
 
+- The crate should be `#[no_std]` compatible again (https://github.com/Kobzol/rust-delegate/pull/74).
+
 # 0.12.0 (22. 12. 2023)
 
 - Add new `#[newtype]` function parameter modifier ([#64](https://github.com/Kobzol/rust-delegate/pull/64)).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -866,13 +866,13 @@ pub fn delegate(tokens: TokenStream) -> TokenStream {
                         ReturnExpression::Into(type_name) => {
                             body = match type_name {
                                 Some(name) => {
-                                    quote::quote! { ::std::convert::Into::<#name>::into(#body) }
+                                    quote::quote! { ::core::convert::Into::<#name>::into(#body) }
                                 }
-                                None => quote::quote! { ::std::convert::Into::into(#body) },
+                                None => quote::quote! { ::core::convert::Into::into(#body) },
                             };
                         }
                         ReturnExpression::TryInto => {
-                            body = quote::quote! { ::std::convert::TryInto::try_into(#body) };
+                            body = quote::quote! { ::core::convert::TryInto::try_into(#body) };
                         }
                         ReturnExpression::Unwrap => {
                             body = quote::quote! { #body.unwrap() };


### PR DESCRIPTION
Noted [here](https://github.com/Kobzol/rust-delegate/issues/65#issuecomment-2307786986).