### PR TITLE
Add `#[expr(/* template */)]` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Dev
 
-- Add `#[const(path::to::Trait::CONST)]` attribute to delegate associated constants via a getter.
-- Add `#[expr(<$ template>)]` attribute to modify delegated call using custom code (thanks to @vic1707).
+- Add `#[const(path::to::Trait::CONST)]` attribute to delegate associated constants via a getter (implemented by @vic1707).
+- Add `#[expr(<$ template>)]` attribute to modify delegated call using custom code (implemented by @vic1707).
 
 # 0.13.2 (14. 1. 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Dev
 
 - Add `#[const(path::to::Trait::CONST)]` attribute to delegate associated constants via a getter.
-- Add `#[expr(<$ template>)]` attribute to modify delegated call using custom code.
+- Add `#[expr(<$ template>)]` attribute to modify delegated call using custom code (thanks to @vic1707).
 
 # 0.13.2 (14. 1. 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Dev
 
 - Add `#[const(path::to::Trait::CONST)]` attribute to delegate associated constants via a getter.
+- Add `#[expr(<$ template>)]` attribute to modify delegated call using custom code.
 
 # 0.13.2 (14. 1. 2025)
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,33 @@ impl<T> Stack<T> {
   }
   ```
 
+- Custom called expression
+
+The `#[expr()]` attribute can be used to modify the delegated call. You can use the `$` sigil as a placeholder for what delegate would normally expand to, and wrap that expression with custom code.
+
+_Note:_ the `$` placeholder isn't required and can be present multiple times if you want.
+
+```rs
+struct A(Vec<u8>);
+
+impl A {
+    delegate! {
+        to self.0 {
+            #[expr(*$.unwrap())]
+            /// Here `$` == `self.0.get(idx)`
+            /// Will expand to `*self.0.get(idx).unwrap()`
+            fn get(&self, idx: usize) -> u8;
+
+            #[call(get)]
+            #[expr($?.checked_pow(2))]
+            /// Here `$` == `self.0.get(idx)`
+            /// Will expand to `self.0.get(idx)?.checked_pow(2)`
+            fn get_checked_pow_2(&self, idx: usize) -> Option<u8>;
+        }
+    }
+}
+```
+
 - Add additional arguments to method
 
   ```rust
@@ -414,7 +441,6 @@ impl Enum {
 }
 
 assert_eq!(Enum::A(A).get_toto(), <A as WithConst>::TOTO);
-
 ```
 
 ## License

--- a/tests/expr_attribute.rs
+++ b/tests/expr_attribute.rs
@@ -1,0 +1,47 @@
+extern crate delegate;
+use delegate::delegate;
+
+#[test]
+fn delegate_with_custom_expr() {
+    struct A(Vec<u8>);
+
+    impl A {
+        delegate! {
+            to self.0 {
+                #[expr(*$.unwrap())]
+                fn get(&self, idx: usize) -> u8;
+
+                #[call(get)]
+                #[expr($?.checked_pow(2))]
+                fn get_checked_pow_2(&self, idx: usize) -> Option<u8>;
+            }
+        }
+    }
+
+    let a = A(vec![2, 3, 4, 5]);
+
+    assert_eq!(a.get(0), 2);
+    assert_eq!(a.get_checked_pow_2(0), Some(4));
+
+    // out-of-bounds behavior
+    assert!(std::panic::catch_unwind(|| a.get(4)).is_err());
+    assert_eq!(a.get_checked_pow_2(4), None);
+}
+
+#[test]
+fn delegate_without_placeholder() {
+    struct A(Vec<u8>);
+
+    impl A {
+        delegate! {
+            to self.0 {
+                #[expr(Some("test"))]
+                fn get_name(&self) -> Option<&'static str>;
+            }
+        }
+    }
+
+    let a = A(vec![2, 3, 4, 5]);
+
+    assert_eq!(a.get_name(), Some("test"));
+}


### PR DESCRIPTION
fixes(?) #59

Currently a wip, can be tested with

```rs
struct A(Result<i16, &'static str>);
impl A {
    delegate::delegate!{
        to self.0 {
            #[expr(foo($expr.unwrap()?))] // error when we have ($
            fn as_i16(self) -> i16;
            #[expr($expr.unwrap_err()?.tata())]
            fn as_str(self) -> &'static str;
        }
    }
}
```